### PR TITLE
Allow static JS config to reference environment variables

### DIFF
--- a/assets/js/config/static.js
+++ b/assets/js/config/static.js
@@ -1,9 +1,13 @@
 export default {
 
-    baseUri: 'https://test.hicube.caida.org',
+    // the various process.env variables are defined in .env.local
+
+    charthouseVersion: process.env.CH_VERSION,
+
+    baseUri: 'https://' + process.env.CH_VERSION + '.hicube.caida.org',
 
     api: {
-        url: 'https://api.hicube.caida.org/test',
+        url: 'https://api.hicube.caida.org/' + process.env.CH_API_VERSION,
         timeout: 1000
     },
 

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
         "classnames": "^2.2.6",
         "crossfilter": "^1.3.12",
         "d3": "3",
+        "dotenv-webpack": "^1.7.0",
         "font-awesome": "^4.7.0",
         "has": "^1.0.3",
         "highcharts": "5.0.14",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,5 +1,6 @@
 const path = require('path');
 const CopyWebpackPlugin = require('copy-webpack-plugin');
+const Dotenv = require('dotenv-webpack');
 const Encore = require('@symfony/webpack-encore');
 
 Encore
@@ -75,7 +76,7 @@ Encore
         babelConfig.plugins.push('syntax-dynamic-import');
         babelConfig.plugins.push('transform-object-rest-spread');
         babelConfig.plugins.push('istanbul');
-    });
+    })
 ;
 
 let webpackConfig = Encore.getWebpackConfig();
@@ -101,6 +102,13 @@ webpackConfig.plugins.push(
     new CopyWebpackPlugin([
         { from: './assets/images/logos/', to: 'images/'}
     ])
+);
+
+
+webpackConfig.plugins.push(
+    new Dotenv({
+        path: './.env.local',
+    })
 );
 
 module.exports = webpackConfig;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2516,6 +2516,25 @@ domutils@1.5.1:
     dom-serializer "0"
     domelementtype "1"
 
+dotenv-defaults@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/dotenv-defaults/-/dotenv-defaults-1.0.2.tgz#441cf5f067653fca4bbdce9dd3b803f6f84c585d"
+  integrity sha512-iXFvHtXl/hZPiFj++1hBg4lbKwGM+t/GlvELDnRtOFdjXyWP7mubkVr+eZGWG62kdsbulXAef6v/j6kiWc/xGA==
+  dependencies:
+    dotenv "^6.2.0"
+
+dotenv-webpack@^1.7.0:
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/dotenv-webpack/-/dotenv-webpack-1.7.0.tgz#4384d8c57ee6f405c296278c14a9f9167856d3a1"
+  integrity sha512-wwNtOBW/6gLQSkb8p43y0Wts970A3xtNiG/mpwj9MLUhtPCQG6i+/DSXXoNN7fbPCU/vQ7JjwGmgOeGZSSZnsw==
+  dependencies:
+    dotenv-defaults "^1.0.2"
+
+dotenv@^6.2.0:
+  version "6.2.0"
+  resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-6.2.0.tgz#941c0410535d942c8becf28d3f357dbd9d476064"
+  integrity sha512-HygQCKUBSFl8wKQZBSemMywRWcEDNidvNbjGVyZu3nbZ8qq9ubiPoGLMdRDpfSrpkkm9BXYFkpKxxFX38o/76w==
+
 duplexer2@~0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/duplexer2/-/duplexer2-0.1.4.tgz#8b12dab878c0d69e3e7891051662a32fc6bddcc1"


### PR DESCRIPTION
Under the hood this is done using webpack to replace any `process.env.FOO` instances with the variable value from the `.env.local` file. In this way it plays nicely with the symfony way of configuring such things.