### PR TITLE
sankey graphs fixes

### DIFF
--- a/assets/js/Hijacks/components/sankeyGraph.jsx
+++ b/assets/js/Hijacks/components/sankeyGraph.jsx
@@ -13,6 +13,7 @@ class SankeyGraph extends React.Component {
     }
 
     _count_links(paths, benign_nodes, suspicious_nodes){
+        console.log(benign_nodes, suspicious_nodes);
         let nodes = new Set();
         let links = {};
         for (let path of paths) {
@@ -70,6 +71,8 @@ class SankeyGraph extends React.Component {
                 let style = "color:grey";
                 if (benign && !suspicious){
                     style = "color:grey"
+                } else if (benign && suspicious){
+                    style = "color:orange"
                 } else if (suspicious){
                     style = "color:red"
                 }


### PR DESCRIPTION
- revert weight calculation to count instead of log-scale of count
- plot paths with both oldcomer and newcomer orange (grey for only oldcomer, red for only newcomer)