### PR TITLE
fix issue on extracting largest prefix for submoas

### DIFF
--- a/assets/js/Hijacks/components/event-details-table.jsx
+++ b/assets/js/Hijacks/components/event-details-table.jsx
@@ -117,7 +117,7 @@ class EventDetailsTable extends React.Component {
                                     <td>{data.event_details_type}</td>
                                 </tr>
                                 <tr>
-                                    <th>Largest prefix:</th>
+                                    <th>Largest (sub)prefix:</th>
                                     <td> <IPPrefix prefix={data.largest_prefix}/> </td>
                                 </tr>
                                 <tr>

--- a/assets/js/Hijacks/components/events-table.jsx
+++ b/assets/js/Hijacks/components/events-table.jsx
@@ -9,7 +9,11 @@ import React from 'react';
 import DataTable from 'react-data-table-component';
 import axios from 'axios';
 import SearchBar from "./search-bar";
-import {translate_suspicion_str_to_values, translate_suspicion_values_to_str} from "../utils/events";
+import {
+    extract_largest_prefix,
+    translate_suspicion_str_to_values,
+    translate_suspicion_values_to_str
+} from "../utils/events";
 import AsNumber from "./asn";
 import IPPrefix from "./ip-prefix";
 
@@ -62,22 +66,11 @@ const columns = [
         },
     },
     {
-        name: 'Largest Prefix',
+        name: 'Largest (Sub)Prefix',
         selector: 'prefixes',
         width: "160px",
         cell: row => {
-            let data = row.prefixes;
-            let maxsize = 32;
-            let maxpfx = data[0];
-            for (let pfx in data.slice(1)) {
-                let size = parseInt(pfx.split("/")[1]);
-                if (size < maxsize) {
-                    maxsize = size;
-                    maxpfx = pfx
-                }
-
-            }
-            return <IPPrefix prefix={maxpfx}/>
+            return <IPPrefix prefix={extract_largest_prefix(row)}/>
         }
     },
     {


### PR DESCRIPTION
use `extract_largest_prefix` function defined in `utils/event.js` instead of duplicate the largest prefix checking code. [`extract_largest_prefix`][1] looks among all prefixes in moas and edges events, and all sub-prefixes in submoas and defcon events, and returns the largest prefixes seen.  

also revise table column titles from "largest prefix" to "largest (sub)prefix" for clarity.

[1]:https://github.com/CAIDA/charthouse-ui/blob/a4ab782228d98cdc4a861038ed2665c1f1abe3a0/assets/js/Hijacks/utils/events.js#L18