### PR TITLE
Observatory V2 API

### DIFF
--- a/assets/js/Hi3/pages/feeds/hijacks/event_details.jsx
+++ b/assets/js/Hi3/pages/feeds/hijacks/event_details.jsx
@@ -3,11 +3,8 @@ import axios from "axios";
 import 'Hi3/css/pages/feeds/hijacks.css';
 import EventDetailsTable from "../../../../Hijacks/components/event-details-table";
 import PfxEventsTable from "../../../../Hijacks/components/pfx-events-table";
-import EventSuspicionTable from "../../../../Hijacks/components/event-suspicion-table";
 import EventTrTagsTable from "../../../../Hijacks/components/event-tr-tags-table";
 import queryString from "query-string";
-
-const HORIZONTAL_OFFSET = 480;
 
 class EventDetails extends React.Component {
 
@@ -89,14 +86,14 @@ class EventDetails extends React.Component {
                 </div>
 
 
-                <div>
-                    { debug &&
-                    <EventSuspicionTable suspicion_tags={this.state.eventData.inference.suspicion.suspicion_tags}
-                                         all_tags={this.state.eventData.tags}
-                                         title={"Tags Suspicion Table"}
-                    />
-                    }
-                </div>
+                {/*<div>*/}
+                {/*    { debug &&*/}
+                {/*    <EventSuspicionTable suspicion_tags={this.state.eventData.inference.suspicion.suspicion_tags}*/}
+                {/*                         all_tags={this.state.eventData.tags}*/}
+                {/*                         title={"Tags Suspicion Table"}*/}
+                {/*    />*/}
+                {/*    }*/}
+                {/*</div>*/}
 
                 <div>
                     {this.state.tagsData!==undefined && debug &&
@@ -109,7 +106,7 @@ class EventDetails extends React.Component {
 
                 <div>
                     <PfxEventsTable data={this.state.eventData.pfx_events}
-                                    inference={this.state.eventData.inference}
+                                    tagsData={this.state.tagsData}
                                     eventId={this.eventId}
                                     eventType={this.eventType}
                                     isEventDetails={true}

--- a/assets/js/Hijacks/components/pfx-events-table.jsx
+++ b/assets/js/Hijacks/components/pfx-events-table.jsx
@@ -2,7 +2,7 @@ import React from "react";
 import DataTable from "react-data-table-component";
 import PropTypes from "prop-types";
 import TagsList from "./tags-list";
-import {extract_tags_dict_from_inference} from "../utils/tags";
+import {extract_tags_tr_worthiness} from "../utils/tags";
 import IPPrefix from "./ip-prefix";
 import LinkA from "../../Hi3/components/linka";
 
@@ -111,7 +111,7 @@ class PfxEventsTable extends React.Component {
                     }
 
                     let ases = origins.map(asn=>{
-                        return <a href={`https://asrank.caida.org/asns?asn=${asn}`} target="_blank"> AS{asn} </a>
+                        return <a key={`pfx-asn-${asn}`} href={`https://asrank.caida.org/asns?asn=${asn}`} target="_blank"> AS{asn} </a>
                     }).reduce((prev, curr) => [prev, ', ', curr]);
 
                     return <React.Fragment>
@@ -180,11 +180,12 @@ class PfxEventsTable extends React.Component {
         ];
     };
 
-    preprocessData(pfx_events, inference) {
+    preprocessData(pfx_events, tags_data) {
 
         let processed = [];
 
-        let tags_inference_dict = extract_tags_dict_from_inference(inference);
+        let tags_tr_worthy_dict = extract_tags_tr_worthiness(tags_data);
+
 
         for (let pfx_event of pfx_events) {
             let event = {};
@@ -213,7 +214,7 @@ class PfxEventsTable extends React.Component {
             event.fingerprint = prefixes.join("_")
                 .replace(/\//g, "-");
             pfx_event.tags.forEach((tag_name)=>{
-                tags_dict[tag_name] = tag_name in tags_inference_dict? tags_inference_dict[tag_name]: "unknown";
+                tags_dict[tag_name] = tag_name in tags_tr_worthy_dict? tags_tr_worthy_dict[tag_name]: "unknown";
             });
             event.tags_dict=tags_dict;
             event.details=pfx_event.details;
@@ -223,7 +224,7 @@ class PfxEventsTable extends React.Component {
     }
 
     render() {
-        let data = this.preprocessData(this.props.data, this.props.inference);
+        let data = this.preprocessData(this.props.data, this.props.tagsData);
         let columns = [];
         if (["moas", "edges"].includes(this.props.eventType)) {
             columns = this.columns1

--- a/assets/js/Hijacks/components/tag.jsx
+++ b/assets/js/Hijacks/components/tag.jsx
@@ -25,12 +25,15 @@ class Tag extends React.Component{
 
         switch(type){
             case "suspicious":
+            case "yes":
                 res = "danger";
                 break;
             case "grey":
+            case "na":
                 res = "warning";
                 break;
             case "benign":
+            case "no":
                 res = "success";
                 break;
             case "unknown":
@@ -52,12 +55,9 @@ class Tag extends React.Component{
     }
 
     render() {
-        let name = this.props.render_name? this._renderTagName(this.props.name): this.props.name;
+        let name = this._renderTagName(this.props.name);
         let type = this._translateType(this.props.type);
         let search_term = `?tags=${this.props.name}`;
-        if(this.props.is_code){
-            search_term = `?codes=${this.props.name}`;
-        }
         return (
             <Link to={{
                 pathname:"/feeds/hijacks/events",

--- a/assets/js/Hijacks/components/tags-list.jsx
+++ b/assets/js/Hijacks/components/tags-list.jsx
@@ -39,23 +39,19 @@ class TagsList extends React.Component {
 
     render() {
         let tags = this.props.tags;
-        let is_code = !!this.props.is_code;
-        let render_name = !is_code;
         let tagDefinitions = this.state.tagDefinitions;
 
+        console.log(tags);
         return (
             <div className="tags-list" onClick={(e) => this.handleClick(e)}>
                 {Object.keys(tags).map(function(tag_name, index){
                     let definition = "";
-                    let tag_key = is_code? `tag-${tag_name}` : `code-${tag_name}`;
                     if(tag_name in tagDefinitions){
                         definition = tagDefinitions[tag_name].definition;
                     }
                     return <Tag key={`tag-${tag_name}`}
                                 name={tag_name}
-                                render_name={render_name}
-                                type={tags[tag_name]["type"]}
-                                is_code={is_code}
+                                type={tags[tag_name]}
                                 definition={definition}/>
                 })}
             </div>

--- a/assets/js/Hijacks/utils/tags.js
+++ b/assets/js/Hijacks/utils/tags.js
@@ -34,38 +34,21 @@ function tr_str_to_value(tr_worthiness){
     }
 }
 
-function extract_tags_dict_from_inference(inference){
-    if(inference===undefined){
+function extract_tags_tr_worthiness(tags_data){
+    if(tags_data===undefined){
         return {};
     }
-    let tags_dict = {};
-    let tags_dict_tmp = {};
-    for(let tag_comb_info of inference.suspicion.suspicion_tags){
-        for(let tag of tag_comb_info.tags){
-            if(tag in tags_dict_tmp){
-                if(tags_dict_tmp[tag].confidence>tag_comb_info.confidence){
-                    tags_dict_tmp[tag]={
-                        "level": tag_comb_info.suspicion_level,
-                        "confidence": tag_comb_info.confidence,
-                    }
-                }
-            } else {
-                tags_dict_tmp[tag]={
-                    "level": tag_comb_info.suspicion_level,
-                    "confidence": tag_comb_info.confidence,
-                }
+
+    let tags_tr_worthy_dict = {};
+    for(let combination of tags_data["tr_worthy"]){
+        let worthy = combination["worthy"];
+        for(let tag of combination["tags"]){
+            if(!(tag in tags_tr_worthy_dict)){
+                tags_tr_worthy_dict[tag] = worthy;
             }
         }
     }
-
-    for(let tag_name of Object.keys(tags_dict_tmp)){
-        let tag_info = tags_dict_tmp[tag_name];
-        tags_dict[tag_name] = {
-            "type": suspicion_level_to_type(tag_info.level)
-        }
-    }
-
-    return tags_dict;
+    return tags_tr_worthy_dict;
 }
 
-export {suspicion_level_to_type, extract_tags_dict_from_inference, tr_to_type}
+export {suspicion_level_to_type, extract_tags_tr_worthiness, tr_to_type}


### PR DESCRIPTION
Revise UI to make sure the new interface is compatible with the observatory V2 api.

- [x] all pages open without error
- [x] tags render ok
- [x] add inference result to event list
- [ ] add inference result to event table
- [ ] add inferences to prefix event table
- [ ] fix victims and attackers rendering for prefix events (potentially update the API to provide this information)
