### PR TITLE
set initial page to be parsed curPage

### DIFF
--- a/assets/js/Hijacks/components/events-table.jsx
+++ b/assets/js/Hijacks/components/events-table.jsx
@@ -428,6 +428,7 @@ class EventsTable extends React.Component {
                         fixedHeader={true}
                         pagination
                         paginationServer
+                        paginationDefaultPage={this.query.curPage+1}
                         paginationTotalRows={this.state.totalRows}
                         paginationPerPage={this.query.perPage}
                         paginationRowsPerPageOptions={[10, 30, 50, 100]}


### PR DESCRIPTION
`this.query.curPage` is parsed when loading a page with urls. for loading
pages with `start` set to be on other pages, we use the `curPage` to
properly set the page number on the tables' pagination ui.