### PR TITLE
When checking for a user's role, check both realm and client roles

### DIFF
--- a/assets/js/auth/index.js
+++ b/assets/js/auth/index.js
@@ -181,10 +181,18 @@ class Auth {
         if (!idtoken) {
              return false;
         }
-        if (!idtoken.hasOwnProperty('realmroles')) {
-             return false;
+
+        if (idtoken.hasOwnProperty('realmroles')) {
+            if (idtoken.realmroles.includes(role)) {
+                 return true;
+            }
         }
-        return idtoken.realmroles.includes(role);
+        if (idtoken.hasOwnProperty('roles')) {
+            if (idtoken.roles.includes(role)) {
+                return true;
+            }
+        }
+        return false;
     }
 
     getProfile(cb) {


### PR DESCRIPTION
Fixes issue where the explorer page would not load on the test server, even if the user had the correct `ui:explorer` role.