### PR TITLE
load tags data in pfx_event page

### DIFF
--- a/assets/js/Hi3/pages/feeds/hijacks/pfx_event_details.jsx
+++ b/assets/js/Hi3/pages/feeds/hijacks/pfx_event_details.jsx
@@ -48,10 +48,12 @@ class PfxEventDetails extends React.Component {
         super(props);
         this.eventId = this.props.match.params.eventId;
         this.jsonUrl = `https://bgp.caida.org/json/event/id/${this.eventId}`;
+        this.tagsUrl = `https://bgp.caida.org/json/tags`;
         this.fingerprint = this.props.match.params.pfxEventId;
         this.eventType = this.eventId.split("-")[0];
         this.state = {
             eventData: {},
+            tagsData: {},
             subpaths: [],
             superpaths: [],
             pfxEvent: [],
@@ -66,6 +68,14 @@ class PfxEventDetails extends React.Component {
     componentDidMount() {
         this.loadEventData();
         this.loadPfxEventData();
+        this.loadTagsData();
+    }
+
+    async loadTagsData() {
+        const response = await axios.get(this.tagsUrl);
+        this.setState({
+            tagsData: response.data,
+        });
     }
 
     loadEventData = async() => {
@@ -240,6 +250,7 @@ class PfxEventDetails extends React.Component {
                                 inference={this.state.eventData.inference}
                                 eventType={this.eventType}
                                 eventId={this.eventId}
+                                tagsData={this.state.tagsData}
                                 isEventDetails={false}
                                 enableClick={false} enablePagination={false}
                             />

--- a/assets/js/Hijacks/utils/tags.js
+++ b/assets/js/Hijacks/utils/tags.js
@@ -69,7 +69,7 @@ function tr_str_to_value(tr_worthiness){
 }
 
 function extract_tags_tr_worthiness(tags_data){
-    if(tags_data===undefined){
+    if(tags_data===undefined || tags_data==={}){
         return {};
     }
 


### PR DESCRIPTION
this allows rendering color in the pfx event datails table.

This fixes:
- https://github.com/CAIDA/bgphijacks-tools/issues/474
- https://github.com/CAIDA/bgphijacks-tools/issues/483